### PR TITLE
fetch함수 구현

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -5,6 +5,8 @@ import Main from "./pages/Main/Main";
 import CreateTodo from "./pages/Main/CreateTodo";
 import Blank from "./pages/Main/Blank";
 import TodoLayout from "./pages/Main/TodoLayout";
+import ModifyForm from "./pages/Main/ModifyForm";
+import DetailForm from "./pages/Main/DetailForm";
 
 const Router = () => {
   return (
@@ -13,7 +15,10 @@ const Router = () => {
         <Route path="/login" element={<AuthLayout />} />
         <Route element={<Main />}>
           <Route path="/" element={<Blank />} />
-          <Route path="/detail/:id" element={<TodoLayout />} />
+          <Route element={<TodoLayout />}>
+            <Route path="/detail/:id" element={<DetailForm />} />
+            <Route path="/modify/:id" element={<ModifyForm />} />
+          </Route>
           <Route path="/create" element={<CreateTodo />} />
         </Route>
       </Routes>

--- a/src/components/utility/fetchapi.ts
+++ b/src/components/utility/fetchapi.ts
@@ -1,0 +1,53 @@
+// const requestHeaders: HeadersInit = new Headers();
+// requestHeaders.set("Content-Type", "application/json");
+// requestHeaders.set("Authorization", localStorage.getItem("token") || "");
+
+export const fetchapi = {
+  get: async (url: string, requestHeaders: HeadersInit): Promise<Response> => {
+    const result = await fetch(url, { headers: requestHeaders });
+    return result;
+  },
+  post: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "POST",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+  delete: async (
+    url: string,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, { method: "DELETE", headers: requestHeaders });
+    return result;
+  },
+  put: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "PUT",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+  create: async <T>(
+    url: string,
+    parameter: T,
+    requestHeaders: HeadersInit
+  ): Promise<Response> => {
+    const result = fetch(url, {
+      method: "",
+      headers: requestHeaders,
+      body: JSON.stringify(parameter),
+    });
+    return result;
+  },
+};

--- a/src/components/utility/requestHeaders.ts
+++ b/src/components/utility/requestHeaders.ts
@@ -1,0 +1,4 @@
+export const requestHeaders: HeadersInit = new Headers();
+requestHeaders.set("Content-Type", "application/json");
+requestHeaders.set("Authorization", localStorage.getItem("token") || "");
+console.log("hi");

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,6 @@
+const BASE_URL = "http://localhost:8080";
+
+export const config = {
+  Auth: `${BASE_URL}/users`,
+  Todo: `${BASE_URL}/todos`,
+};

--- a/src/pages/Main/CreateTodo.tsx
+++ b/src/pages/Main/CreateTodo.tsx
@@ -1,48 +1,47 @@
 import React, { ChangeEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import { fetchapi } from "../../components/utility/fetchapi";
+import { requestHeaders } from "../../components/utility/requestHeaders";
+import { config } from "../../config";
 
 const CreateTodo = () => {
   const [inputData, setInputData] = useState({ title: "", content: "" });
   const navigate = useNavigate();
 
-  function titleHandler({ target }: ChangeEvent<HTMLInputElement>) {
+  function titleInputHandler({ target }: ChangeEvent<HTMLInputElement>) {
     setInputData((prev) => ({ ...prev, title: target.value }));
   }
 
-  function contentHandler({ target }: ChangeEvent<HTMLTextAreaElement>) {
+  function contentInputHandler({ target }: ChangeEvent<HTMLTextAreaElement>) {
     setInputData((prev) => ({ ...prev, content: target.value }));
   }
 
   async function submitTodo() {
     try {
-      const requestHeaders: HeadersInit = new Headers();
-      requestHeaders.set("Content-Type", "application/json");
-      requestHeaders.set("Authorization", localStorage.getItem("token") || "");
-
-      const response = await fetch("http://localhost:8080/todos", {
-        method: "POST",
-        headers: requestHeaders,
-        body: JSON.stringify(inputData),
-      });
+      const response = await fetchapi.post(
+        `${config.Todo}`,
+        inputData,
+        requestHeaders
+      );
       if (response.ok) {
         navigate("/");
       } else {
         alert("통신에러 다시시도해주세요");
       }
     } catch (e) {
-      alert("다시시도해주세요");
+      alert("다시 시도해주세요");
     }
   }
 
   return (
     <CreatePage>
       <TitleInput
-        onChange={(event) => titleHandler(event)}
+        onChange={(event) => titleInputHandler(event)}
         placeholder="제목"
       />
       <ContentInput
-        onChange={(event) => contentHandler(event)}
+        onChange={(event) => contentInputHandler(event)}
         placeholder="내용"
       />
       <SubmitButton onClick={submitTodo}>생성하기</SubmitButton>

--- a/src/pages/Main/DetailForm.tsx
+++ b/src/pages/Main/DetailForm.tsx
@@ -1,34 +1,27 @@
-import React, { Dispatch, ReactElement, SetStateAction } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { ReactElement } from "react";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import styled from "styled-components";
+import { fetchapi } from "../../components/utility/fetchapi";
+import { requestHeaders } from "../../components/utility/requestHeaders";
+import { config } from "../../config";
 import { TodoListProp } from "./Main";
 
 interface DetailFormFunction {
-  (param: {
-    isModify: boolean;
-    setIsModify: Dispatch<SetStateAction<boolean>>;
-    detailInfo: TodoListProp;
-  }): ReactElement;
+  (): ReactElement;
 }
 
-const DetailForm: DetailFormFunction = ({
-  setIsModify,
-  isModify,
-  detailInfo,
-}) => {
+interface ContextParameter {
+  detailInfo: TodoListProp;
+}
+
+const DetailForm: DetailFormFunction = () => {
   const navigate = useNavigate();
+  const { detailInfo } = useOutletContext<ContextParameter>();
 
-  async function deleteTodo(id: string | undefined) {
-    const requestHeaders: HeadersInit = new Headers();
-    requestHeaders.set("Content-Type", "application/json");
-    requestHeaders.set("Authorization", localStorage.getItem("token") || "");
-
-    const response = await fetch(
-      `http://localhost:8080/todos/${detailInfo.id}`,
-      {
-        method: "DELETE",
-        headers: requestHeaders,
-      }
+  async function deleteTodo(todoItemId: string | undefined) {
+    const response = await fetchapi.delete(
+      `${config.Todo}/${todoItemId}`,
+      requestHeaders
     );
     if (response.ok) {
       navigate("/");
@@ -37,8 +30,8 @@ const DetailForm: DetailFormFunction = ({
     }
   }
 
-  function changeTodo() {
-    setIsModify(!isModify);
+  function goModify(todoItemId: string | undefined) {
+    navigate(`/modify/${todoItemId}`);
   }
 
   return (
@@ -46,7 +39,9 @@ const DetailForm: DetailFormFunction = ({
       <DetailTitle>Title : {detailInfo.title}</DetailTitle>
       <DetailContent>Content : {detailInfo.content}</DetailContent>
       <ButtonWrapper>
-        <ModifyButton onClick={() => changeTodo()}>수정하기</ModifyButton>
+        <ModifyButton onClick={() => goModify(detailInfo.id)}>
+          수정하기
+        </ModifyButton>
         <DeleteButton onClick={() => deleteTodo(detailInfo.id)}>
           삭제하기
         </DeleteButton>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -8,6 +8,9 @@ import {
 } from "react-router-dom";
 import styled from "styled-components";
 import TodoList from "./TodoList";
+import { fetchapi } from "../../components/utility/fetchapi";
+import { config } from "../../config";
+import { requestHeaders } from "../../components/utility/requestHeaders";
 
 export interface TodoListProp {
   title: string;
@@ -27,15 +30,21 @@ const Main: MainFunction = () => {
   const location = useLocation();
 
   useEffect(() => {
-    const requestHeaders: HeadersInit = new Headers();
-    requestHeaders.set("Content-Type", "application/json");
-    requestHeaders.set("Authorization", localStorage.getItem("token") || "");
-
-    fetch("http://localhost:8080/todos", {
-      headers: requestHeaders,
-    })
-      .then((res) => (res.ok ? res.json() : alert("통신에러")))
-      .then((res) => setTodoList(res.data));
+    if (localStorage.getItem("token")) {
+      (async function () {
+        try {
+          const response = await fetchapi.get(`${config.Todo}`, requestHeaders);
+          if (response.ok) {
+            const result = await response.json();
+            setTodoList(result.data);
+          } else {
+            alert("다시 접속해 주세요");
+          }
+        } catch (error) {
+          alert("통신에러입니다 다시 시도해주세요");
+        }
+      })();
+    }
   }, [location.pathname.split("/")[1]]);
 
   function goCreate() {
@@ -53,8 +62,10 @@ const Main: MainFunction = () => {
       <TodoListWrapper>
         <TodoLists>
           {todoList.length !== 0 &&
-            todoList.map((item) => {
-              return <TodoList data={item} key={item.id}></TodoList>;
+            todoList.map((listItem) => {
+              return (
+                <TodoList listItem={listItem} key={listItem.id}></TodoList>
+              );
             })}
         </TodoLists>
         <TodoDetail>
@@ -63,7 +74,7 @@ const Main: MainFunction = () => {
       </TodoListWrapper>
     </TodoMain>
   ) : (
-    <Navigate to={"/login"} replace={true}></Navigate>
+    <Navigate to={"/login"} replace />
   );
 };
 

--- a/src/pages/Main/ModifyForm.tsx
+++ b/src/pages/Main/ModifyForm.tsx
@@ -4,45 +4,37 @@ import React, {
   ReactElement,
   ChangeEvent,
 } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import styled from "styled-components";
+import { fetchapi } from "../../components/utility/fetchapi";
+import { requestHeaders } from "../../components/utility/requestHeaders";
+import { config } from "../../config";
 import { TodoListProp } from "./Main";
 
 interface ModifyFormFunction {
-  (param: {
-    isModify: boolean;
-    setIsModify: Dispatch<SetStateAction<boolean>>;
-    detailInfo: TodoListProp;
-    setDetailInfo: Dispatch<SetStateAction<TodoListProp>>;
-  }): ReactElement;
+  (): ReactElement;
 }
 
-const ModifyForm: ModifyFormFunction = ({
-  isModify,
-  setIsModify,
-  setDetailInfo,
-  detailInfo,
-}) => {
+interface ContextParameter {
+  detailInfo: TodoListProp;
+  setDetailInfo: Dispatch<SetStateAction<TodoListProp>>;
+}
+
+const ModifyForm: ModifyFormFunction = () => {
+  const { detailInfo, setDetailInfo } = useOutletContext<ContextParameter>();
   const navigate = useNavigate();
 
   async function modifyTodo() {
-    const requestHeaders: HeadersInit = new Headers();
-    requestHeaders.set("Content-Type", "application/json");
-    requestHeaders.set("Authorization", localStorage.getItem("token") || "");
-
-    const response = await fetch(
-      `http://localhost:8080/todos/${detailInfo.id}`,
+    const response = await fetchapi.put<{ title: string; content: string }>(
+      `${config.Todo}/${detailInfo.id}`,
       {
-        method: "PUT",
-        headers: requestHeaders,
-        body: JSON.stringify({
-          title: detailInfo.title,
-          content: detailInfo.content,
-        }),
-      }
+        title: detailInfo.title,
+        content: detailInfo.content,
+      },
+      requestHeaders
     );
     if (response.ok) {
-      setIsModify(!isModify);
+      navigate(`/detail/${detailInfo.id}`, { replace: true });
     } else {
       alert("다시 시도해주세요");
     }

--- a/src/pages/Main/TodoList.tsx
+++ b/src/pages/Main/TodoList.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { TodoListProp } from "./Main";
 
-const TodoList = ({ data: { title, id } }: { data: TodoListProp }) => {
+const TodoList = ({ listItem: { title, id } }: { listItem: TodoListProp }) => {
   const navigate = useNavigate();
 
   function goDetail(id: string) {


### PR DESCRIPTION
fetch 로직을 fetchapi 로 따로 만들어서 객체로 만들어 각각의 페이지에서 필요한 method로 나누어서 관리하도록 하였습니다.

fetchapi 변수를 만들어 객체로 함수를 관리하여 필요한 곳에서 fetchapi를 import하여 fetchapi.get() fetchapi.post() 이런식으로 활용하였습니다.

requestHeaders 파일을 따로 관리하여 fetch의 header 부분에 적용할 수 있게 import 해오는 방식으로 구현하였습니다.